### PR TITLE
Navbar contribution

### DIFF
--- a/src/components/common/Navbar.jsx
+++ b/src/components/common/Navbar.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect, useRef  } from 'react'
 import PropTypes from 'prop-types'
 
 // Constants
@@ -16,6 +16,7 @@ import ThemeSwitch from './ThemeSwitch'
 
 function NavBar(props) {
   const [isDropdownOpen, setDropdownOpen] = useState(false); // Add state to track dropdown visibility
+  const dropdownRef = useRef(null); // Reference for the dropdown menu
 
   const navLinkClasses = classAdd(getClassesFromConstants(classLists.navLink), "flex", "flex-row", "items-center")
 
@@ -121,13 +122,32 @@ function NavBar(props) {
     setDropdownOpen(false); // Close dropdown when a link is clicked
   };
 
+  // Add event listener to handle clicks outside the dropdown
+  useEffect(() => {
+    const handleClickOutside = (event) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target)) {
+        setDropdownOpen(false); // Close the dropdown if clicked outside
+      }
+    };
+
+    if (isDropdownOpen) {
+      document.addEventListener('mousedown', handleClickOutside);
+    } else {
+      document.removeEventListener('mousedown', handleClickOutside);
+    }
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside); // Clean up the event listener on unmount
+    };
+  }, [isDropdownOpen]);
+
   return (
     <div
     id="navbar"
     className="navbar bg-bg1 rounded-md shadow-md m-auto mt-10 flex justify-between sticky opacity-90  backdrop-blur-3xl bg-tertiary/40 z-[100]"
   >
       <div className="navbar-start w-full flex flex-row justify-between ">
-        <div className=''>
+        <div className='' ref={dropdownRef}>
           <div className="dropdown">
             {/* MSG: made this dropdown view permanenet */}
             {/* <div tabIndex="0" role="button" className="btn btn-ghost xl:hidden"> */}


### PR DESCRIPTION
Hello, this PR deals with the bug described in issue #22. 

The bug: hamburger menu had to be clicked twice to re-open when it was closed by clicking outside the menu. 

The fix: 
- Added logic to ensure the `handleClickOutside` event listener does not interfere when the dropdown is reopened.
- Updated the state management to prevent the dropdown from briefly opening and then closing after an outside click.

Since #26 has a messy commit history due to the `dev` branch not being in sync with the `main` branch, I'm creating this PR to `main` so changes are easier to view. Please let me know if this works.
